### PR TITLE
Add Cargo.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+Cargo.lock


### PR DESCRIPTION
It's common, even [recommended practice](https://doc.rust-lang.org/cargo/faq.html#why-do-binaries-have-cargolock-in-version-control-but-not-libraries) to include `Cargo.lock` in the git repo for binary crates. Quoting from the linked page:

> ... As a result, it is recommended that all binaries check in their Cargo.lock.

I'm assuming you've chosen not to do so for some intentional reason, but I'd like to not have the repo become dirty whenever I build the project, thus the request to add `Cargo.lock` to `.gitignore`.

(If you decide to instead add a `Cargo.lock` to the repo, then please close this PR without merging.)