### PR TITLE
Disallow trailing whitespace on any line

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Features:
 * Check that `[[test]]` are sorted by test name
 * Check all members of top-level object arrays (like) `[[test]]` are placed contiguously
 * Checks that the file ends with exactly one new line
+* Checks that no line contains trailing whitespace
 
 This is a best-effort linter. Currently custom parsing is really simplified, so it may:
 

--- a/tests/Trailing-white-space.toml
+++ b/tests/Trailing-white-space.toml
@@ -1,0 +1,11 @@
+[package]
+name = "testproj"
+version = "0.1.0"
+edition = "2022"
+
+[dependencies.a]
+version = "1"
+random = ["data", "points"] 
+
+[dependencies.c]
+version = "1"

--- a/tests/binary_tests.rs
+++ b/tests/binary_tests.rs
@@ -252,3 +252,34 @@ fn missing_end_of_line() {
         .failure()
         .stderr("Error: \"File does not end with a new line\"\n");
 }
+
+#[test]
+fn trailing_white_space() {
+    let assert = Command::cargo_bin(assert_cmd::crate_name!())
+        .unwrap()
+        .arg("./tests/Trailing-white-space.toml")
+        .arg("--no-cargo-verify")
+        .arg("-Nn")
+        .arg("-Dn")
+        .arg("-Tn")
+        .arg("-An")
+        .arg("-En")
+        .assert();
+
+    assert.success();
+
+    let assert = Command::cargo_bin(assert_cmd::crate_name!())
+        .unwrap()
+        .arg("./tests/Trailing-white-space.toml")
+        .arg("--no-cargo-verify")
+        .arg("-Ny")
+        .arg("-Dstrict")
+        .arg("-Ty")
+        .arg("-Ay")
+        .arg("-Ey")
+        .assert();
+
+    assert
+        .failure()
+        .stderr("Error: \"Line 8 ends with trailing whitespace\"\n");
+}


### PR DESCRIPTION
Known issue: This does not account for multi-line literal strings, where trailing whitespace would be legal.

Workaround: If that's needed, disable this option via `-En`.