### PR TITLE
Issue #16: Fix the error on invocation by `cargo toml-lint`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,29 +6,27 @@
 
 Features:
 
-* Verify toml syntax
-* Run `cargo verify-project`
-* Check that `[dependencies]` and `[dev-dependencies]` are sorted alphabetically
-* Check that `[[test]]` are sorted by test name
-* Check all members of top-level object arrays (like) `[[test]]` are placed contiguously
-* Checks that the file ends with exactly one new line
-* Checks that no line contains trailing whitespace
+- Verify TOML syntax
+- Run `cargo verify-project`
+- Check that `[dependencies]` and `[dev-dependencies]` are sorted alphabetically
+- Check that `[[test]]` are sorted by test name
+- Check all members of top-level object arrays (like) `[[test]]` are placed contiguously
+- Checks that the file ends with exactly one new line
+- Checks that no line contains trailing whitespace
 
-This is a best-effort linter. Currently custom parsing is really simplified, so it may:
+This is a best-effort linter. Currently, custom parsing is really simplified, so it may:
 
-* Reject some valid files if they are written in some particularly obscure way
-* Accept some files that violate the given linting rules
+- Reject some valid files if they are written in some particularly obscure way
+- Accept some files that violate the given linting rules
 
 However, any such issues are considered bugs and a fix PR would be appreciated.
 
 ## License
 
-Licensed under either of
+This project is licensed under the following licenses as per your choice.
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
-
-at your option.
+- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 ### Contribution
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ This is a best-effort linter. Currently, custom parsing is really simplified, so
 
 However, any such issues are considered bugs and a fix PR would be appreciated.
 
+## Usage
+
+This linter can be used from the command line:
+
+```bash
+cargo toml-lint
+```
+
+You can also specify a specific file with the `-t` or `--target` flag:
+
+```bash
+cargo toml-lint --target ./packages/Cargo.toml
+```
+
 ## License
 
 This project is licensed under the following licenses as per your choice.

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,13 +56,6 @@ enum DependencySorting {
 fn main() -> Result<(), String> {
     let args = Args::parse();
 
-    println!("Linting {:?}", &args);
-
-    // Print the current working directory
-    let _cwd = std::env::current_dir()
-        .map_err(|err| format!("Could not get current directory: {:?}", err))?;
-    println!("Current directory: {:?}", _cwd);
-
     let contents = fs::read(&args.target)
         .map_err(|err| format!("Could not read {:?}: {:?}", &args.target, err))?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ struct Args {
     no_trailing_whitespace: Toggle,
 
     /// File to lint
+    #[clap(short = 't', long, default_value = "Cargo.toml")]
     target: PathBuf,
 }
 
@@ -54,6 +55,13 @@ enum DependencySorting {
 
 fn main() -> Result<(), String> {
     let args = Args::parse();
+
+    println!("Linting {:?}", &args);
+
+    // Print the current working directory
+    let _cwd = std::env::current_dir()
+        .map_err(|err| format!("Could not get current directory: {:?}", err))?;
+    println!("Current directory: {:?}", _cwd);
 
     let contents = fs::read(&args.target)
         .map_err(|err| format!("Could not read {:?}: {:?}", &args.target, err))?;

--- a/tests/binary_tests.rs
+++ b/tests/binary_tests.rs
@@ -4,6 +4,7 @@ use assert_cmd::Command;
 fn self_test() {
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./Cargo.toml")
         .assert();
 
@@ -14,6 +15,7 @@ fn self_test() {
 fn ok_test() {
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Ok-but-weird.toml")
         .arg("--no-cargo-verify")
         .assert();
@@ -22,6 +24,7 @@ fn ok_test() {
 
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Ok-but-weird.toml")
         .arg("--no-cargo-verify")
         .arg("-Dsection")
@@ -31,6 +34,7 @@ fn ok_test() {
 
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Ok-but-weird.toml")
         .arg("--no-cargo-verify")
         .arg("-Dnone")
@@ -43,6 +47,7 @@ fn ok_test() {
 fn should_pass_test() {
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Should-pass.toml")
         .arg("--no-cargo-verify")
         .assert();
@@ -51,6 +56,7 @@ fn should_pass_test() {
 
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Should-pass.toml")
         .arg("--no-cargo-verify")
         .arg("-Dsection")
@@ -60,6 +66,7 @@ fn should_pass_test() {
 
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Should-pass.toml")
         .arg("--no-cargo-verify")
         .arg("-Dnone")
@@ -72,6 +79,7 @@ fn should_pass_test() {
 fn unsorted_deps() {
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Unsorted-deps.toml")
         .arg("--no-cargo-verify")
         .arg("-Dnone")
@@ -82,6 +90,7 @@ fn unsorted_deps() {
 
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Unsorted-deps.toml")
         .arg("--no-cargo-verify")
         .arg("-Dsection")
@@ -94,6 +103,7 @@ fn unsorted_deps() {
 
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Unsorted-deps.toml")
         .arg("--no-cargo-verify")
         .arg("-Dstrict")
@@ -109,6 +119,7 @@ fn unsorted_deps() {
 fn unsorted_deps_only_strict_fails() {
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Unsorted-deps-strict.toml")
         .arg("--no-cargo-verify")
         .arg("-Dn")
@@ -120,6 +131,7 @@ fn unsorted_deps_only_strict_fails() {
 
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Unsorted-deps-strict.toml")
         .arg("--no-cargo-verify")
         .arg("-Dsection")
@@ -131,6 +143,7 @@ fn unsorted_deps_only_strict_fails() {
 
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Unsorted-deps-strict.toml")
         .arg("--no-cargo-verify")
         .arg("-Dstrict")
@@ -147,6 +160,7 @@ fn unsorted_deps_only_strict_fails() {
 fn unsorted_tests() {
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Unsorted-tests.toml")
         .arg("--no-cargo-verify")
         .arg("-Dn")
@@ -158,6 +172,7 @@ fn unsorted_tests() {
 
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Unsorted-tests.toml")
         .arg("--no-cargo-verify")
         .arg("-Dstrict")
@@ -174,6 +189,7 @@ fn unsorted_tests() {
 fn split_test_array() {
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Split-test-array.toml")
         .arg("--no-cargo-verify")
         .arg("-Dn")
@@ -185,6 +201,7 @@ fn split_test_array() {
 
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Split-test-array.toml")
         .arg("--no-cargo-verify")
         .arg("-Dn")
@@ -199,6 +216,7 @@ fn split_test_array() {
 fn extra_end_of_line() {
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Extra-end-of-line.toml")
         .arg("--no-cargo-verify")
         .arg("-Nn")
@@ -211,6 +229,7 @@ fn extra_end_of_line() {
 
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Extra-end-of-line.toml")
         .arg("--no-cargo-verify")
         .arg("-Ny")
@@ -228,6 +247,7 @@ fn extra_end_of_line() {
 fn missing_end_of_line() {
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Missing-end-of-line.toml")
         .arg("--no-cargo-verify")
         .arg("-Nn")
@@ -240,6 +260,7 @@ fn missing_end_of_line() {
 
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Missing-end-of-line.toml")
         .arg("--no-cargo-verify")
         .arg("-Ny")
@@ -257,6 +278,7 @@ fn missing_end_of_line() {
 fn trailing_white_space() {
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Trailing-white-space.toml")
         .arg("--no-cargo-verify")
         .arg("-Nn")
@@ -270,6 +292,7 @@ fn trailing_white_space() {
 
     let assert = Command::cargo_bin(assert_cmd::crate_name!())
         .unwrap()
+        .arg("-t")
         .arg("./tests/Trailing-white-space.toml")
         .arg("--no-cargo-verify")
         .arg("-Ny")


### PR DESCRIPTION
This PR closes the #16 issue.

The original issue was that the `Cargo.toml` file was used as a positional argument, and the system was set to expect that. However, from my research, cargo plugins prefer either subcommands or flags. Thus, when we would type `cargo toml-lint` instead of `cargo-toml-lint`, it would consume `toml-lint` as the positional argument and complain about the `Cargo.toml`.

I have fixed that by doing two things:

1. Add a `-t/--target` option to the binary
2. Set `Cargo.toml` as a default value for the target option.

The result is that the arguments to the CLI are more consistent now and the UX is simpler as well (`cargo toml-lint`, instead of specifying the whole file path).

This has also been added to the README.


Signed-off-by: Ali Sajid Imami <395482+AliSajid@users.noreply.github.com>